### PR TITLE
`gmon` requires target binary to be built with go1.23+ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 - amd64 (x86_64)
 - Linux Kernel 5.8+ since `gmon` uses [BPF ring buffer](https://nakryiko.com/posts/bpf-ringbuf/)
+- Target Go binary must be compiled with Go 1.23+ since `gmon` uses fixed offset to get goroutine ID
 
 # Usage
 

--- a/ebpf/c/gmon.c
+++ b/ebpf/c/gmon.c
@@ -24,9 +24,9 @@ int runtime_newproc1(struct pt_regs *ctx) {
         bpf_printk("%s:%d | failed to extract new goroutine pointer from retval\n", __FILE__, __LINE__);
         return 0;
     }
-    // `pahole -C runtime.g /path/to/gobinary 2>/dev/null` shows the offsets of the goid which is 152.
+    // `pahole -C runtime.g /path/to/gobinary 2>/dev/null` shows the offsets of the goid.
     int64_t goid = 0;
-    if (bpf_core_read_user(&goid, sizeof(int64_t), newg_p + 152)) {
+    if (bpf_core_read_user(&goid, sizeof(int64_t), newg_p + 160)) {
         bpf_printk("%s:%d | failed to read goroutine id from newg with the offset\n", __FILE__, __LINE__);
         return 0;
     }

--- a/ebpf/c/goroutine.h
+++ b/ebpf/c/goroutine.h
@@ -18,7 +18,7 @@ struct gobuf_t {
     uintptr_t bp;
 };
 
-// https://github.com/golang/go/blob/release-branch.go1.21/src/runtime/runtime2.go#L447
+// https://github.com/golang/go/blob/release-branch.go1.23/src/runtime/runtime2.go#L458
 struct g_t {
     struct stack_t stack_instance;
     uintptr_t stackguard0;
@@ -29,6 +29,7 @@ struct g_t {
     struct gobuf_t sched;
     uintptr_t syscallsp;
     uintptr_t syscallpc;
+    uintptr_t syscallbp;
     uintptr_t stktopsp;
     uintptr_t param;
     uint32_t atomicstatus;

--- a/fixture/go.mod
+++ b/fixture/go.mod
@@ -1,3 +1,3 @@
 module fixture
 
-go 1.22.1
+go 1.23.1

--- a/gmon.sh
+++ b/gmon.sh
@@ -43,7 +43,7 @@ ln -s /usr/bin/llvm-strip-14 /usr/bin/llvm-strip
 ln -s /usr/bin/clang-14 /usr/bin/clang
 ln -s /usr/bin/clang-format-14 /usr/bin/clang-format
 wget -O- --no-check-certificate https://github.com/libbpf/bpftool/releases/download/v7.3.0/bpftool-v7.3.0-amd64.tar.gz | tar -xzf - -C /usr/bin && chmod +x /usr/bin/bpftool
-wget -O- --no-check-certificate https://go.dev/dl/go1.22.3.linux-amd64.tar.gz | tar -xzf - -C /usr/local && chmod +x /usr/local/go/bin/go && ln -s /usr/local/go/bin/go /usr/bin/go
+wget -O- --no-check-certificate https://go.dev/dl/go1.23.1.linux-amd64.tar.gz | tar -xzf - -C /usr/local && chmod +x /usr/local/go/bin/go && ln -s /usr/local/go/bin/go /usr/bin/go
 END
 WORKDIR /usr/src
 COPY go.mod go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keisku/gmon
 
-go 1.22.3
+go 1.23.1
 
 require (
 	github.com/cilium/ebpf v0.15.0


### PR DESCRIPTION
Motivation: https://github.com/keisku/gmon/issues/18